### PR TITLE
[UPD] 初始化 V3 框架

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "colorthief": "^3.3.1",
     "compare-versions": "^6.1.1",
     "fast-average-color": "^9.5.1",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "path-browserify": "^1.0.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
@@ -31,7 +31,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.27",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.27.5",
     "npm-check-updates": "^20.0.0",
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^9.5.1
         version: 9.5.1
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
@@ -53,13 +53,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1))
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)
       esbuild:
-        specifier: ^0.27.4
-        version: 0.27.4
+        specifier: ^0.27.5
+        version: 0.27.5
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.1.0)
@@ -86,10 +86,10 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1)
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1)
       vite-plugin-css-injected-by-js:
         specifier: ^4.0.1
-        version: 4.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1))
+        version: 4.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1))
 
 packages:
 
@@ -143,6 +143,9 @@ packages:
 
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -201,158 +204,158 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
-  '@esbuild/aix-ppc64@0.27.4':
-    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+  '@esbuild/aix-ppc64@0.27.5':
+    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.4':
-    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+  '@esbuild/android-arm64@0.27.5':
+    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.4':
-    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+  '@esbuild/android-arm@0.27.5':
+    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.4':
-    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+  '@esbuild/android-x64@0.27.5':
+    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.4':
-    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+  '@esbuild/darwin-arm64@0.27.5':
+    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.4':
-    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+  '@esbuild/darwin-x64@0.27.5':
+    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.4':
-    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+  '@esbuild/freebsd-arm64@0.27.5':
+    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.4':
-    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+  '@esbuild/freebsd-x64@0.27.5':
+    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.4':
-    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+  '@esbuild/linux-arm64@0.27.5':
+    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.4':
-    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+  '@esbuild/linux-arm@0.27.5':
+    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.4':
-    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+  '@esbuild/linux-ia32@0.27.5':
+    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.4':
-    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+  '@esbuild/linux-loong64@0.27.5':
+    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.4':
-    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+  '@esbuild/linux-mips64el@0.27.5':
+    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.4':
-    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+  '@esbuild/linux-ppc64@0.27.5':
+    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.4':
-    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+  '@esbuild/linux-riscv64@0.27.5':
+    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.4':
-    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+  '@esbuild/linux-s390x@0.27.5':
+    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.4':
-    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+  '@esbuild/linux-x64@0.27.5':
+    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+  '@esbuild/netbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.4':
-    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+  '@esbuild/netbsd-x64@0.27.5':
+    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.4':
-    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+  '@esbuild/openbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.4':
-    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+  '@esbuild/openbsd-x64@0.27.5':
+    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.4':
-    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+  '@esbuild/openharmony-arm64@0.27.5':
+    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.4':
-    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+  '@esbuild/sunos-x64@0.27.5':
+    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.4':
-    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+  '@esbuild/win32-arm64@0.27.5':
+    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.4':
-    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+  '@esbuild/win32-ia32@0.27.5':
+    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.4':
-    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+  '@esbuild/win32-x64@0.27.5':
+    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -996,14 +999,14 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  electron-to-chromium@1.5.330:
-    resolution: {integrity: sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==}
+  electron-to-chromium@1.5.331:
+    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  esbuild@0.27.4:
-    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+  esbuild@0.27.5:
+    resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1286,8 +1289,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1311,8 +1314,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   npm-check-updates@20.0.0:
     resolution: {integrity: sha512-qCs02x51irGf0okCttwv8lHEO2NxT903IJ2bKpG82kIzkm6pfT3CoWB5YIvqY/wi/DdnYRfI7eVfCYYymQgvCg==}
@@ -1655,6 +1658,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
@@ -1743,82 +1751,82 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
-  '@esbuild/aix-ppc64@0.27.4':
+  '@esbuild/aix-ppc64@0.27.5':
     optional: true
 
-  '@esbuild/android-arm64@0.27.4':
+  '@esbuild/android-arm64@0.27.5':
     optional: true
 
-  '@esbuild/android-arm@0.27.4':
+  '@esbuild/android-arm@0.27.5':
     optional: true
 
-  '@esbuild/android-x64@0.27.4':
+  '@esbuild/android-x64@0.27.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.4':
+  '@esbuild/darwin-arm64@0.27.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.4':
+  '@esbuild/darwin-x64@0.27.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.4':
+  '@esbuild/freebsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.4':
+  '@esbuild/freebsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.4':
+  '@esbuild/linux-arm64@0.27.5':
     optional: true
 
-  '@esbuild/linux-arm@0.27.4':
+  '@esbuild/linux-arm@0.27.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.4':
+  '@esbuild/linux-ia32@0.27.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.4':
+  '@esbuild/linux-loong64@0.27.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.4':
+  '@esbuild/linux-mips64el@0.27.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.4':
+  '@esbuild/linux-ppc64@0.27.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.4':
+  '@esbuild/linux-riscv64@0.27.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.4':
+  '@esbuild/linux-s390x@0.27.5':
     optional: true
 
-  '@esbuild/linux-x64@0.27.4':
+  '@esbuild/linux-x64@0.27.5':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.4':
+  '@esbuild/netbsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.4':
+  '@esbuild/netbsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.4':
+  '@esbuild/openbsd-arm64@0.27.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.4':
+  '@esbuild/openbsd-x64@0.27.5':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.4':
+  '@esbuild/openharmony-arm64@0.27.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.4':
+  '@esbuild/sunos-x64@0.27.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.4':
+  '@esbuild/win32-arm64@0.27.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.4':
+  '@esbuild/win32-ia32@0.27.5':
     optional: true
 
-  '@esbuild/win32-x64@0.27.4':
+  '@esbuild/win32-x64@0.27.5':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.1.0)':
@@ -1928,7 +1936,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.33.5':
     dependencies:
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-ia32@0.33.5':
@@ -2199,10 +2207,10 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1)
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -2244,8 +2252,8 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001784
-      electron-to-chromium: 1.5.330
-      node-releases: 2.0.36
+      electron-to-chromium: 1.5.331
+      node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
@@ -2319,40 +2327,40 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  electron-to-chromium@1.5.330: {}
+  electron-to-chromium@1.5.331: {}
 
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
 
-  esbuild@0.27.4:
+  esbuild@0.27.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.4
-      '@esbuild/android-arm': 0.27.4
-      '@esbuild/android-arm64': 0.27.4
-      '@esbuild/android-x64': 0.27.4
-      '@esbuild/darwin-arm64': 0.27.4
-      '@esbuild/darwin-x64': 0.27.4
-      '@esbuild/freebsd-arm64': 0.27.4
-      '@esbuild/freebsd-x64': 0.27.4
-      '@esbuild/linux-arm': 0.27.4
-      '@esbuild/linux-arm64': 0.27.4
-      '@esbuild/linux-ia32': 0.27.4
-      '@esbuild/linux-loong64': 0.27.4
-      '@esbuild/linux-mips64el': 0.27.4
-      '@esbuild/linux-ppc64': 0.27.4
-      '@esbuild/linux-riscv64': 0.27.4
-      '@esbuild/linux-s390x': 0.27.4
-      '@esbuild/linux-x64': 0.27.4
-      '@esbuild/netbsd-arm64': 0.27.4
-      '@esbuild/netbsd-x64': 0.27.4
-      '@esbuild/openbsd-arm64': 0.27.4
-      '@esbuild/openbsd-x64': 0.27.4
-      '@esbuild/openharmony-arm64': 0.27.4
-      '@esbuild/sunos-x64': 0.27.4
-      '@esbuild/win32-arm64': 0.27.4
-      '@esbuild/win32-ia32': 0.27.4
-      '@esbuild/win32-x64': 0.27.4
+      '@esbuild/aix-ppc64': 0.27.5
+      '@esbuild/android-arm': 0.27.5
+      '@esbuild/android-arm64': 0.27.5
+      '@esbuild/android-x64': 0.27.5
+      '@esbuild/darwin-arm64': 0.27.5
+      '@esbuild/darwin-x64': 0.27.5
+      '@esbuild/freebsd-arm64': 0.27.5
+      '@esbuild/freebsd-x64': 0.27.5
+      '@esbuild/linux-arm': 0.27.5
+      '@esbuild/linux-arm64': 0.27.5
+      '@esbuild/linux-ia32': 0.27.5
+      '@esbuild/linux-loong64': 0.27.5
+      '@esbuild/linux-mips64el': 0.27.5
+      '@esbuild/linux-ppc64': 0.27.5
+      '@esbuild/linux-riscv64': 0.27.5
+      '@esbuild/linux-s390x': 0.27.5
+      '@esbuild/linux-x64': 0.27.5
+      '@esbuild/netbsd-arm64': 0.27.5
+      '@esbuild/netbsd-x64': 0.27.5
+      '@esbuild/openbsd-arm64': 0.27.5
+      '@esbuild/openbsd-x64': 0.27.5
+      '@esbuild/openharmony-arm64': 0.27.5
+      '@esbuild/sunos-x64': 0.27.5
+      '@esbuild/win32-arm64': 0.27.5
+      '@esbuild/win32-ia32': 0.27.5
+      '@esbuild/win32-x64': 0.27.5
 
   escalade@3.2.0: {}
 
@@ -2590,7 +2598,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -2609,7 +2617,7 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
-  node-releases@2.0.36: {}
+  node-releases@2.0.37: {}
 
   npm-check-updates@20.0.0: {}
 
@@ -2839,11 +2847,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-css-injected-by-js@4.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1)):
+  vite-plugin-css-injected-by-js@4.0.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1)):
     dependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1)
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(sass@1.98.0)(terser@5.46.1):
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.5)(sass@1.98.0)(terser@5.46.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2852,7 +2860,7 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.5.0
-      esbuild: 0.27.4
+      esbuild: 0.27.5
       fsevents: 2.3.3
       sass: 1.98.0
       terser: 5.46.1

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -41,10 +41,11 @@
             }
         },
         ">= 3.0.0": {
-            "orpheus://orpheus/pub/core": {
+            "orpheus://orpheus/pub/hybrid/vendors": {
                 "type": "replace",
-                "from": "function(t,i,e,r,n,a){var o;if(((this.U()||C).from||C).id==t)",
-                "to": "async function(t,i,e,r,n,a){;i='online';window.onProcessLyrics&&(a=(await onProcessLyrics(a,e)));var o;if(((this.U()||C).from||C).id==t)"
+                "id": "redux-dispatch-hook",
+                "from": "\"sagaEffects.put\"),",
+                "to": "\"sagaEffects.put\"),window?.rnpDispatchHook?.(n),"
             }
         }
     }

--- a/src/components/background.tsx
+++ b/src/components/background.tsx
@@ -122,9 +122,9 @@ function GradientBackground(props: {
   useEffect(() => {
     const image = new Image();
     image.crossOrigin = "Anonymous";
-    console.log("loading image");
+    console.log("[RNP] loading image");
     image.onload = () => {
-      console.log("image loaded");
+      console.log("[RNP] image loaded");
       const paletteObjs = getPaletteSync(image);
       const palette = paletteObjs!.map((c: any) => [
         c.rgb().r,
@@ -188,7 +188,7 @@ function FluidBackground(props: {
     }
     setSongId(id);
     fluidContainer.current.classList.toggle("paused", !playState.current);
-    //console.log(id, playState.current, state.split('|')[1], document.querySelector("#main-player .btnp").classList.contains("btnp-pause"));
+    //console.log("[RNP] Play state changed:", id, playState.current, state.split('|')[1], document.querySelector("#main-player .btnp").classList.contains("btnp-pause"));
   };
 
   useEffect(() => {

--- a/src/components/lyrics.tsx
+++ b/src/components/lyrics.tsx
@@ -355,7 +355,7 @@ export function Lyrics(props: {
         try {
           return customScaleFunc(offset);
         } catch (e: any) {
-          console.error("Error in custom scale function", e);
+          console.error("[RNP] Error in custom scale function", e);
         }
       }
       offset = Math.abs(offset);
@@ -368,7 +368,7 @@ export function Lyrics(props: {
         try {
           return customBlurFunc(offset);
         } catch (e: any) {
-          console.error("Error in custom blur function", e);
+          console.error("[RNP] Error in custom blur function", e);
         }
       }
       offset = Math.abs(offset);
@@ -381,7 +381,7 @@ export function Lyrics(props: {
         try {
           return customOpacityFunc(offset);
         } catch (e: any) {
-          console.error("Error in custom opacity function", e);
+          console.error("[RNP] Error in custom opacity function", e);
         }
       }
       offset = Math.abs(offset);

--- a/src/injects/inject.tsx
+++ b/src/injects/inject.tsx
@@ -1,0 +1,234 @@
+import { Background } from "../components/background";
+import { CoverShadow } from "../components/cover-shadow";
+import { Lyrics } from "../components/lyrics";
+import { MiniSongInfo } from "../components/mini-song-info";
+import { showContextMenu } from "../components/context-menu";
+import { whatsNew } from "../components/whats-new";
+import {
+  waitForElement,
+  waitForElementAsync,
+  copyTextToClipboard,
+  getSetting,
+} from "../utils/utils";
+
+export const injectV2 = (
+  updateCDImage: () => void,
+  addSettingsMenu: (isFM?: boolean) => Promise<void>,
+  addFullScreenButton: (dom: HTMLElement) => void,
+  calcAccentColor: (dom: HTMLElement | any, isFM?: boolean) => void,
+) => {
+  new MutationObserver(async () => {
+    // Now playing page
+    if (document!.querySelector(".g-single:not(.patched)")) {
+      // @ts-ignore
+      document.querySelector(".g-single").classList.add("patched");
+      waitForElement(".n-single .cdimg img", (dom: HTMLElement | any) => {
+        dom.addEventListener("load", updateCDImage);
+        new MutationObserver(updateCDImage).observe(dom, {
+          attributes: true,
+          attributeFilter: ["src"],
+        });
+
+        dom.addEventListener("contextmenu", (e: any) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const imageURL = dom.src
+            .replace(/^orpheus:\/\/cache\/\?/, "")
+            .replace(/\?.*$/, "");
+          showContextMenu(e.clientX, e.clientY, [
+            {
+              label: "复制图片地址",
+              callback: () => {
+                copyTextToClipboard(imageURL);
+              },
+            },
+            {
+              label: "在浏览器中打开图片",
+              callback: () => {
+                // @ts-ignore
+                betterncm.app.exec(`${imageURL}`);
+              },
+            },
+          ]);
+        });
+      });
+
+      waitForElement(
+        ".g-single .g-singlec-ct .n-single .mn .head .inf",
+        (dom: HTMLElement | any) => {
+          const addCopySelectionToItems = (items: any, closetSelector: any) => {
+            const selection = (window! as any).getSelection();
+            if (
+              selection.toString().trim() &&
+              selection.baseNode.parentElement.closest(closetSelector)
+            ) {
+              const selectedText = selection.toString().trim();
+              items.unshift({
+                label: "复制",
+                callback: () => {
+                  copyTextToClipboard(selectedText);
+                },
+              });
+            }
+          };
+          dom.addEventListener("contextmenu", (e: any) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            if (e.target.closest(".title .name")) {
+              const songName = dom.querySelector(".title .name").innerText;
+              const items = [
+                {
+                  label: "复制歌曲名",
+                  callback: () => {
+                    copyTextToClipboard(songName);
+                  },
+                },
+              ];
+              addCopySelectionToItems(items, ".title .name");
+              showContextMenu(e.clientX, e.clientY, items);
+              return;
+            }
+
+            if (e.target.closest(".info .alias")) {
+              const songAlias = dom.querySelector(".info .alias").innerText;
+              const items = [
+                {
+                  label: "复制歌曲别名",
+                  callback: () => {
+                    copyTextToClipboard(songAlias);
+                  },
+                },
+              ];
+              addCopySelectionToItems(items, ".info .alias");
+              showContextMenu(e.clientX, e.clientY, items);
+              return;
+            }
+          });
+        },
+      );
+
+      const background = document.createElement("div");
+      background.classList.add("rnp-bg");
+      ReactDOM.render(
+        <Background
+          type={getSetting("background-type", "fluid")}
+          // @ts-ignore
+          image={await waitForElementAsync!(".n-single .cdimg img" as any)}
+        />,
+        background,
+      );
+      // @ts-ignore
+      document.querySelector(".g-single").appendChild(background);
+
+      const coverShadowController = document.createElement("div");
+      coverShadowController.classList.add("rnp-cover-shadow-controller");
+      ReactDOM.render(
+        <CoverShadow
+          image={await waitForElementAsync(".n-single .cdimg img")}
+        />,
+        coverShadowController,
+      );
+      document.body.appendChild(coverShadowController);
+
+      waitForElement(
+        ".g-single-track .g-singlec-ct .n-single .mn .lyric",
+        (oldLyrics: any) => {
+          oldLyrics.remove();
+        },
+      );
+      const lyrics = document.createElement("div");
+      lyrics.classList.add("lyric");
+      ReactDOM.render(<Lyrics />, lyrics);
+      waitForElement(
+        ".g-single-track .g-singlec-ct .n-single .wrap",
+        (dom: HTMLElement | any) => {
+          dom.appendChild(lyrics);
+        },
+      );
+
+      const miniSongInfo = document.createElement("div");
+      miniSongInfo.classList.add("rnp-mini-song-info");
+      setTimeout(async () => {
+        ReactDOM.render(
+          <MiniSongInfo
+            image={await waitForElementAsync(".n-single .cdimg img")}
+            infContainer={await waitForElementAsync(
+              ".g-single .g-singlec-ct .n-single .mn .head .inf" as any,
+            )}
+          />,
+          miniSongInfo,
+        );
+        // @ts-ignore
+        document.querySelector(".g-single").appendChild(miniSongInfo);
+      }, 0);
+
+      addSettingsMenu();
+      // @ts-ignore
+      addFullScreenButton(document.querySelector(".g-single"));
+
+      whatsNew();
+    }
+  }).observe(document.body, { childList: true });
+
+  // 私人 FM
+  const patchFM = async () => {
+    if (
+      document!.querySelector("#page_pc_userfm_songplay:not(.patched)" as any)
+    ) {
+      // @ts-ignore
+      document
+        .querySelector("#page_pc_userfm_songplay")
+        .classList.add("patched");
+      FMObserver.disconnect();
+
+      const lyrics = document!.createElement("div" as any);
+      lyrics.classList.add("lyric");
+      // @ts-ignore
+      document.querySelector("#page_pc_userfm_songplay").appendChild(lyrics);
+      ReactDOM.render(<Lyrics isFM={true} />, lyrics);
+      for (let i = 0; i < 15; i++) {
+        setTimeout(() => {
+          window.dispatchEvent(new Event("resize"));
+        }, 200 * i);
+      }
+
+      const background = document.createElement("div");
+      background.classList.add("rnp-bg", "fm-bg");
+      ReactDOM.render(
+        <Background
+          type={getSetting("background-type", "fluid")}
+          image={await waitForElementAsync(
+            "#page_pc_userfm_songplay .fmplay .covers",
+          )}
+          isFM={true}
+          imageChangedCallback={(dom: HTMLElement | any) => {
+            if (!dom) return;
+            calcAccentColor(dom, true);
+          }}
+        />,
+        background,
+      );
+      // @ts-ignore
+      document
+        .querySelector("#page_pc_userfm_songplay")
+        .appendChild(background);
+      addSettingsMenu(true);
+    }
+  };
+  let FMObserver = new MutationObserver(patchFM);
+  window.addEventListener("hashchange", async () => {
+    if (!window.location.hash.startsWith("#/m/fm/")) {
+      FMObserver.disconnect();
+      return;
+    }
+    for (let i = 0; i < 10; i++) {
+      setTimeout(() => {
+        window.dispatchEvent(new Event("recalc-lyrics"));
+        window.dispatchEvent(new Event("recalc-title"));
+      }, 50 * i);
+    }
+    FMObserver.observe(document.body, { childList: true });
+    window.dispatchEvent(new Event("recalc-lyrics"));
+  });
+};

--- a/src/injects/v3/inject.tsx
+++ b/src/injects/v3/inject.tsx
@@ -1,0 +1,22 @@
+import { Background } from "../../components/background";
+import { CoverShadow } from "../../components/cover-shadow";
+import { Lyrics } from "../../components/lyrics";
+import { MiniSongInfo } from "../../components/mini-song-info";
+import { showContextMenu } from "../../components/context-menu";
+import { whatsNew } from "../../components/whats-new";
+import {
+  waitForElement,
+  waitForElementAsync,
+  copyTextToClipboard,
+  getSetting,
+} from "../../utils/utils";
+
+export const injectV3 = (
+  updateCDImage: () => void,
+  addSettingsMenu: (isFM?: boolean) => Promise<void>,
+  addFullScreenButton: (dom: HTMLElement) => void,
+  calcAccentColor: (dom: HTMLElement | any, isFM?: boolean) => void,
+) => {
+  // TODO: Implement v3 inject logic
+  console.log("Loading v3 inject logic...");
+};

--- a/src/injects/v3/inject.tsx
+++ b/src/injects/v3/inject.tsx
@@ -17,6 +17,35 @@ export const injectV3 = (
   addFullScreenButton: (dom: HTMLElement) => void,
   calcAccentColor: (dom: HTMLElement | any, isFM?: boolean) => void,
 ) => {
-  // TODO: Implement v3 inject logic
-  console.log("Loading v3 inject logic...");
+  (window as any).rnpDispatchHook = (actionWrapper: any) => {
+    if (actionWrapper?.type === "PUT") {
+      const action = actionWrapper?.payload?.action;
+      if (action?.type === "lyric/updateLyric" && action.payload) {
+        if (typeof (window as any).onProcessLyrics === "function") {
+          try {
+            const rawLyrics = action.payload;
+            const songId = rawLyrics.trackId || (window as any).lastSongID;
+            let processed = (window as any).onProcessLyrics(
+              rawLyrics,
+              songId,
+              true,
+            );
+            if (processed && typeof processed.then !== "function") {
+              action.payload = processed;
+            } else if (processed && typeof processed.then === "function") {
+              processed
+                .then((res: any) => {
+                  if (res) {
+                    action.payload = res;
+                  }
+                })
+                .catch((e: any) => console.error("[RNP] ", e));
+            }
+          } catch (e) {
+            console.error("[RNP] Error in rnpDispatchHook onProcessLyrics:", e);
+          }
+        }
+      }
+    }
+  };
 };

--- a/src/liblyric/index.ts
+++ b/src/liblyric/index.ts
@@ -299,8 +299,8 @@ export function parseLyric(
             v.originalLyric as string,
           );
           const weight = similarity * 1000 + ((v as any)[field] ? 1 : 0);
-          //console.log("similarity", similarity, line.originalLyric, v.originalLyric);
-          //console.log("weight", index, weight, line.originalLyric, v.originalLyric);
+          //console.log("[RNP] similarity", similarity, line.originalLyric, v.originalLyric);
+          //console.log("[RNP] weight", index, weight, line.originalLyric, v.originalLyric);
           if (weight < minWeight) {
             minWeight = weight;
             targetIndex = index;
@@ -339,13 +339,13 @@ export function parseLyric(
     const romanParsed = attachOriginalLyric(parsePureLyric(roman));
     const rawParsed = attachOriginalLyric(parsePureLyric(original));
 
-    //console.log("translatedParsed", JSON.parse(JSON.stringify(translatedParsed)));
+    //console.log("[RNP] translatedParsed", JSON.parse(JSON.stringify(translatedParsed)));
 
     attachLyricToDynamic(translatedParsed, "translatedLyric");
     attachLyricToDynamic(romanParsed, "romanLyric");
     attachLyricToDynamic(rawParsed, "rawLyric");
 
-    //console.log("processed", JSON.parse(JSON.stringify(processed)));
+    //console.log("[RNP] processed", JSON.parse(JSON.stringify(processed)));
 
     // 插入空行
     for (let i = 0; i < processed.length; i++) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1214,19 +1214,26 @@ plugin.onLoad(async (p: any) => {
   }
 
   // 区分并加载网易云版本
-  // 当需要时可以在此检测版本，分别注入不同的 DOM 监视或者直接同时注入
-  injectV2(
-    updateCDImage,
-    addSettingsMenu,
-    addFullScreenButton,
-    calcAccentColor,
-  );
-  injectV3(
-    updateCDImage,
-    addSettingsMenu,
-    addFullScreenButton,
-    calcAccentColor,
-  );
+  // @ts-ignore
+  const ncmVersion =
+    typeof betterncm !== "undefined" ? betterncm.ncm.getNCMVersion() : "";
+  if (ncmVersion.startsWith("3.")) {
+    console.log("[RNP] Loading v3 inject logic...");
+    injectV3(
+      updateCDImage,
+      addSettingsMenu,
+      addFullScreenButton,
+      calcAccentColor,
+    );
+  } else {
+    console.log("[RNP] Loading v2 inject logic...");
+    injectV2(
+      updateCDImage,
+      addSettingsMenu,
+      addFullScreenButton,
+      calcAccentColor,
+    );
+  }
 
   new MutationObserver(() => {
     recalculateTitleSize();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1170,6 +1170,9 @@ new MutationObserver(() => {
   }
 }).observe(document.body, { attributes: true, attributeFilter: ["class"] });
 
+import { injectV2 } from "./injects/inject";
+import { injectV3 } from "./injects/v3/inject";
+
 // intercept src setter of HTMLImageElement
 const _src = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "src");
 Object.defineProperty(HTMLImageElement!.prototype, "src", {
@@ -1210,157 +1213,20 @@ plugin.onLoad(async (p: any) => {
     document.body.classList.add("no-material-you-theme");
   }
 
-  new MutationObserver(async () => {
-    // Now playing page
-    if (document!.querySelector(".g-single:not(.patched)")) {
-      // @ts-ignore
-      document.querySelector(".g-single").classList.add("patched");
-      waitForElement(".n-single .cdimg img", (dom: HTMLElement | any) => {
-        dom.addEventListener("load", updateCDImage);
-        new MutationObserver(updateCDImage).observe(dom, {
-          attributes: true,
-          attributeFilter: ["src"],
-        });
-
-        dom.addEventListener("contextmenu", (e: any) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const imageURL = dom.src
-            .replace(/^orpheus:\/\/cache\/\?/, "")
-            .replace(/\?.*$/, "");
-          showContextMenu(e.clientX, e.clientY, [
-            {
-              label: "复制图片地址",
-              callback: () => {
-                copyTextToClipboard(imageURL);
-              },
-            },
-            {
-              label: "在浏览器中打开图片",
-              callback: () => {
-                betterncm.app.exec(`${imageURL}`);
-              },
-            },
-          ]);
-        });
-      });
-
-      waitForElement(
-        ".g-single .g-singlec-ct .n-single .mn .head .inf",
-        (dom: HTMLElement | any) => {
-          const addCopySelectionToItems = (items: any, closetSelector: any) => {
-            const selection = (window! as any).getSelection();
-            if (
-              selection.toString().trim() &&
-              selection.baseNode.parentElement.closest(closetSelector)
-            ) {
-              const selectedText = selection.toString().trim();
-              items.unshift({
-                label: "复制",
-                callback: () => {
-                  copyTextToClipboard(selectedText);
-                },
-              });
-            }
-          };
-          dom.addEventListener("contextmenu", (e: any) => {
-            e.preventDefault();
-            e.stopPropagation();
-
-            if (e.target.closest(".title .name")) {
-              const songName = dom.querySelector(".title .name").innerText;
-              const items = [
-                {
-                  label: "复制歌曲名",
-                  callback: () => {
-                    copyTextToClipboard(songName);
-                  },
-                },
-              ];
-              addCopySelectionToItems(items, ".title .name");
-              showContextMenu(e.clientX, e.clientY, items);
-              return;
-            }
-
-            if (e.target.closest(".info .alias")) {
-              const songAlias = dom.querySelector(".info .alias").innerText;
-              const items = [
-                {
-                  label: "复制歌曲别名",
-                  callback: () => {
-                    copyTextToClipboard(songAlias);
-                  },
-                },
-              ];
-              addCopySelectionToItems(items, ".info .alias");
-              showContextMenu(e.clientX, e.clientY, items);
-              return;
-            }
-          });
-        },
-      );
-
-      const background = document.createElement("div");
-      background.classList.add("rnp-bg");
-      ReactDOM.render(
-        <Background
-          type={getSetting("background-type", "fluid")}
-          image={await waitForElementAsync!(".n-single .cdimg img" as any)}
-        />,
-        background,
-      );
-      // @ts-ignore
-      document.querySelector(".g-single").appendChild(background);
-
-      const coverShadowController = document.createElement("div");
-      coverShadowController.classList.add("rnp-cover-shadow-controller");
-      ReactDOM.render(
-        <CoverShadow
-          image={await waitForElementAsync(".n-single .cdimg img")}
-        />,
-        coverShadowController,
-      );
-      document.body.appendChild(coverShadowController);
-
-      waitForElement(
-        ".g-single-track .g-singlec-ct .n-single .mn .lyric",
-        (oldLyrics: any) => {
-          oldLyrics.remove();
-        },
-      );
-      const lyrics = document.createElement("div");
-      lyrics.classList.add("lyric");
-      ReactDOM.render(<Lyrics />, lyrics);
-      waitForElement(
-        ".g-single-track .g-singlec-ct .n-single .wrap",
-        (dom: HTMLElement | any) => {
-          dom.appendChild(lyrics);
-        },
-      );
-
-      const miniSongInfo = document.createElement("div");
-      miniSongInfo.classList.add("rnp-mini-song-info");
-      setTimeout(async () => {
-        ReactDOM.render(
-          <MiniSongInfo
-            image={await waitForElementAsync(".n-single .cdimg img")}
-            infContainer={await waitForElementAsync(
-              ".g-single .g-singlec-ct .n-single .mn .head .inf" as any,
-            )}
-          />,
-          miniSongInfo,
-        );
-        // @ts-ignore
-        document.querySelector(".g-single").appendChild(miniSongInfo);
-      }, 0);
-
-      addSettingsMenu();
-      // @ts-ignore
-      addFullScreenButton(document.querySelector(".g-single"));
-
-      whatsNew();
-    }
-  }).observe(document.body, { childList: true });
+  // 区分并加载网易云版本
+  // 当需要时可以在此检测版本，分别注入不同的 DOM 监视或者直接同时注入
+  injectV2(
+    updateCDImage,
+    addSettingsMenu,
+    addFullScreenButton,
+    calcAccentColor,
+  );
+  injectV3(
+    updateCDImage,
+    addSettingsMenu,
+    addFullScreenButton,
+    calcAccentColor,
+  );
 
   new MutationObserver(() => {
     recalculateTitleSize();
@@ -1423,67 +1289,6 @@ plugin.onLoad(async (p: any) => {
       }
     }
   }).observe(document.body, { attributes: true, attributeFilter: ["class"] });
-
-  // 私人 FM
-  const patchFM = async () => {
-    if (
-      document!.querySelector("#page_pc_userfm_songplay:not(.patched)" as any)
-    ) {
-      // @ts-ignore
-      document
-        .querySelector("#page_pc_userfm_songplay")
-        .classList.add("patched");
-      FMObserver.disconnect();
-
-      const lyrics = document!.createElement("div" as any);
-      lyrics.classList.add("lyric");
-      // @ts-ignore
-      document.querySelector("#page_pc_userfm_songplay").appendChild(lyrics);
-      ReactDOM.render(<Lyrics isFM={true} />, lyrics);
-      for (let i = 0; i < 15; i++) {
-        setTimeout(() => {
-          window.dispatchEvent(new Event("resize"));
-        }, 200 * i);
-      }
-
-      const background = document.createElement("div");
-      background.classList.add("rnp-bg", "fm-bg");
-      ReactDOM.render(
-        <Background
-          type={getSetting("background-type", "fluid")}
-          image={await waitForElementAsync(
-            "#page_pc_userfm_songplay .fmplay .covers",
-          )}
-          isFM={true}
-          imageChangedCallback={(dom: HTMLElement | any) => {
-            if (!dom) return;
-            (calcAccentColor as any)!(dom, true);
-          }}
-        />,
-        background,
-      );
-      // @ts-ignore
-      document
-        .querySelector("#page_pc_userfm_songplay")
-        .appendChild(background);
-      addSettingsMenu(true);
-    }
-  };
-  let FMObserver = new MutationObserver(patchFM);
-  window.addEventListener("hashchange", async () => {
-    if (!window.location.hash.startsWith("#/m/fm/")) {
-      FMObserver.disconnect();
-      return;
-    }
-    for (let i = 0; i < 10; i++) {
-      setTimeout(() => {
-        window.dispatchEvent(new Event("recalc-lyrics"));
-        window.dispatchEvent(new Event("recalc-title"));
-      }, 50 * i);
-    }
-    FMObserver.observe(document.body, { childList: true });
-    window.dispatchEvent(new Event("recalc-lyrics"));
-  });
 
   // Listen system theme change
   const toggleSystemDarkmodeClass = (media: any) => {

--- a/src/providers/amll-provider.tsx
+++ b/src/providers/amll-provider.tsx
@@ -19,7 +19,7 @@ export const fetchAMLL = async (
     const textContent = await response.text();
     return textContent;
   } catch (e: any) {
-    console.error(`AMLL fetch error for ${ext}`, e);
+    console.error(`[RNP] AMLL fetch error for ${ext}`, e);
     return null;
   }
 };
@@ -345,7 +345,7 @@ const parseTTML = (ttmlContent: any) => {
 
     return lines.sort((a: any, b: any) => a.startTime - b.startTime);
   } catch (e: any) {
-    console.error("TTML Parse Error", e);
+    console.error("[RNP] TTML Parse Error", e);
     return [];
   }
 };

--- a/src/providers/lyric-provider.tsx
+++ b/src/providers/lyric-provider.tsx
@@ -39,8 +39,8 @@ window.onProcessLyrics = (
   }
 
   if ((rawLyrics?.lrc?.lyric ?? "") != currentRawLRC || forceRefresh) {
-    if (forceRefresh) console.log("Force refreshing lyrics");
-    else console.log("Update Raw Lyrics", rawLyrics);
+    if (forceRefresh) console.log("[RNP] Force refreshing lyrics");
+    else console.log("[RNP] Update Raw Lyrics", rawLyrics);
 
     currentRawLRC = rawLyrics?.lrc?.lyric ?? "";
     setTimeout(async () => {
@@ -55,7 +55,7 @@ window.onProcessLyrics = (
 
       if (!processedLyricsToUse && enableCustomLyric && customLyricUrl) {
         try {
-          console.log("Fetching custom lyric from", customLyricUrl);
+          console.log("[RNP] Fetching custom lyric from", customLyricUrl);
           const customResponse = await fetch(customLyricUrl);
           const customText = await customResponse.text();
           const approxLines = customText.split("\n").length;
@@ -76,11 +76,11 @@ window.onProcessLyrics = (
             }
           }
           if (processedLyricsToUse) {
-            console.log("Using Custom Lyric");
+            console.log("[RNP] Using Custom Lyric");
             (window as any).isCustomLyricLoaded = true;
           }
         } catch (e) {
-          console.log("Failed to load custom lyric", e);
+          console.log("[RNP] Failed to load custom lyric", e);
           (window as any).isCustomLyricLoaded = false;
         }
       } else {
@@ -106,7 +106,7 @@ window.onProcessLyrics = (
         const parsed = parseLyric(originalLRCStr, translation, roma, dynamic);
         if (approxLines - parsed.length <= approxLines * 0.7) {
           processedLyricsToUse = parsed;
-          console.log("Using Netease YRC Lyrics");
+          console.log("[RNP] Using Netease YRC Lyrics");
         }
       }
 
@@ -121,7 +121,7 @@ window.onProcessLyrics = (
           const parsed = parseAMLLTTML(ttmlText);
           if (parsed && parsed.length > 0) {
             processedLyricsToUse = parsed;
-            console.log("Using AMLL TTML Lyrics");
+            console.log("[RNP] Using AMLL TTML Lyrics");
           }
         }
       }
@@ -137,7 +137,7 @@ window.onProcessLyrics = (
           const parsed = parseLyric(originalLRCStr, translation, roma, yrcText);
           if (parsed && parsed.length > 0) {
             processedLyricsToUse = parsed;
-            console.log("Using AMLL YRC Lyrics");
+            console.log("[RNP] Using AMLL YRC Lyrics");
           }
         }
       }
@@ -147,7 +147,7 @@ window.onProcessLyrics = (
         const parsed = parseLyric(originalLRCStr, translation, roma);
         if (parsed && parsed.length > 0) {
           processedLyricsToUse = parsed;
-          console.log("Using Netease LRC Lyrics");
+          console.log("[RNP] Using Netease LRC Lyrics");
         }
       }
 
@@ -162,7 +162,7 @@ window.onProcessLyrics = (
           const parsed = parseLyric(lrcText, translation, roma);
           if (parsed && parsed.length > 0) {
             processedLyricsToUse = parsed;
-            console.log("Using AMLL LRC Lyrics");
+            console.log("[RNP] Using AMLL LRC Lyrics");
           }
         }
       }
@@ -170,7 +170,7 @@ window.onProcessLyrics = (
       // Fallback
       if (!processedLyricsToUse) {
         processedLyricsToUse = parseLyric(originalLRCStr, translation, roma);
-        console.log("Using Fallback Lyrics");
+        console.log("[RNP] Using Fallback Lyrics");
       }
 
       if (betterncm.ncm.getPlaying().id !== playingId) {
@@ -241,10 +241,10 @@ window.onProcessLyrics = (
       (lyrics as any).hash =
         `${betterncm.ncm.getPlaying().id}-${cyrb53(processedLyrics.map((x: any) => x.originalLyric).join("\\"))}`;
       window.currentLyrics = lyrics;
-      console.group("Update Processed Lyrics");
-      console.log("lyrics", window.currentLyrics.lyrics);
-      console.log("contributors", window.currentLyrics.contributors);
-      console.log("hash", window.currentLyrics.hash);
+      console.group("[RNP] Update Processed Lyrics");
+      console.log("[RNP] lyrics", window.currentLyrics.lyrics);
+      console.log("[RNP] contributors", window.currentLyrics.contributors);
+      console.log("[RNP] hash", window.currentLyrics.hash);
       console.groupEnd();
       document.dispatchEvent(
         new CustomEvent("lyrics-updated", { detail: window.currentLyrics }),


### PR DESCRIPTION
This pull request updates several dependencies to their latest patch or minor versions, primarily to address bug fixes and maintain compatibility. The main changes are version bumps for `lodash`, `esbuild`, and related packages, as well as updates to other dependencies such as `electron-to-chromium` and `node-releases`. No application logic or source code changes are included.

Dependency updates:

* Upgraded `lodash` from version `4.17.23` to `4.18.1` in both `package.json` and `pnpm-lock.yaml` for improved stability and security. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23-R23) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL33-R34) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1289-R1293)
* Upgraded `esbuild` from `0.27.4` to `0.27.5` and updated all related platform-specific packages and references in `pnpm-lock.yaml` and `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R34) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL56-R62) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL204-R358) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1746-R1829) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2322-R2363) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL999-R1009)

Other dependency bumps:

* Upgraded `electron-to-chromium` from `1.5.330` to `1.5.331` and `node-releases` from `2.0.36` to `2.0.37` to keep browser and Node.js compatibility data current. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1314-R1318) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2247-R2256) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2322-R2363)
* Upgraded `@emnapi/runtime` from `1.9.1` to `1.9.2` and updated all references, improving compatibility for WASM-related dependencies. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR147-R149) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1931-R1939) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1661-R1665)

## Summary by Sourcery

添加具备版本感知能力的注入架构，以同时支持 NCM v2 和 v3 客户端，并将歌词处理接入 v3 的 Redux 流程。

New Features:
- 为 NCM v2 和 v3 引入独立的注入流水线，并在运行时根据检测到的客户端版本选择合适的流水线。
- 接入 NCM v3 的 Redux dispatch 流水线，在歌词更新生效前，通过 `onProcessLyrics` 支持自定义歌词处理。

Enhancements:
- 将现有“正在播放”和 FM 页面上的 DOM 注入逻辑抽取为可复用的 v2 注入器模块。
- 为日志和调试输出添加 `RNP` 前缀标签，以便更容易追踪运行时诊断信息。

Build:
- 在 `package.json` 和 `pnpm-lock.yaml` 中将 `lodash`、`esbuild` 及相关依赖更新到较新的补丁或次要版本，以提升维护性和兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add version-aware injection architecture to support both NCM v2 and v3 clients and wire lyric processing into the v3 Redux flow.

New Features:
- Introduce separate inject pipelines for NCM v2 and v3 and select the appropriate one at runtime based on the detected client version.
- Hook into the NCM v3 Redux dispatch pipeline to allow custom lyric processing via onProcessLyrics before lyric updates are applied.

Enhancements:
- Extract existing now-playing and FM page DOM injection logic into a reusable v2 injector module.
- Prefix logs and debug output with an RNP tag to make runtime diagnostics easier to trace.

Build:
- Update lodash, esbuild, and related dependencies in package.json and pnpm-lock.yaml to newer patch or minor versions for maintenance and compatibility.

</details>